### PR TITLE
Added dot to "Number" abbreviation for correct translation.

### DIFF
--- a/src/GMDatabaseSource.cpp
+++ b/src/GMDatabaseSource.cpp
@@ -223,7 +223,7 @@ void GMDatabaseSource::shuffle(GMTrackList*list,FXuint sort_seed) const {
 void GMDatabaseSource::configure(GMColumnList& list) {
   list.no(17);
   FXint i=0;
-  list[i++]=GMColumn(notr("No"),HEADER_TRACK,GMDBTrackItem::ascendingTrack,GMDBTrackItem::descendingTrack,43,(!playlist) ,true,0);
+  list[i++]=GMColumn(notr("No."),HEADER_TRACK,GMDBTrackItem::ascendingTrack,GMDBTrackItem::descendingTrack,43,(!playlist) ,true,0);
   list[i++]=GMColumn(notr("Queue"),HEADER_QUEUE,GMDBTrackItem::ascendingQueue,GMDBTrackItem::descendingQueue,60,(playlist),false,1);
   list[i++]=GMColumn(notr("Artist"),HEADER_ARTIST,GMDBTrackItem::ascendingArtist,GMDBTrackItem::descendingArtist,400,true,true,3);
   list[i++]=GMColumn(notr("Title"),HEADER_TITLE,GMDBTrackItem::ascendingTitle,GMDBTrackItem::descendingTitle,360,true,true,2);

--- a/src/GMPlayQueue.cpp
+++ b/src/GMPlayQueue.cpp
@@ -64,7 +64,7 @@ GMPlayQueue::~GMPlayQueue() {
 void GMPlayQueue::configure(GMColumnList& list) {
   list.no(17);
   FXint i=0;
-  list[i++]=GMColumn(notr("No"),HEADER_TRACK,GMDBTrackItem::ascendingTrack,GMDBTrackItem::descendingTrack,43,false ,false,0);
+  list[i++]=GMColumn(notr("No."),HEADER_TRACK,GMDBTrackItem::ascendingTrack,GMDBTrackItem::descendingTrack,43,false ,false,0);
   list[i++]=GMColumn(notr("Queue"),HEADER_QUEUE,GMDBTrackItem::ascendingQueue,GMDBTrackItem::descendingQueue,70,true,true,1);
   list[i++]=GMColumn(notr("Artist"),HEADER_ARTIST,GMDBTrackItem::ascendingArtist,GMDBTrackItem::descendingArtist,200,true,true,2);
   list[i++]=GMColumn(notr("Title"),HEADER_TITLE,GMDBTrackItem::ascendingTitle,GMDBTrackItem::descendingTitle,300,true,true,3);

--- a/src/GMStreamSource.cpp
+++ b/src/GMStreamSource.cpp
@@ -55,7 +55,7 @@ GMStreamSource::~GMStreamSource(){
 
 void GMStreamSource::configure(GMColumnList& list){
   list.no(4);
-  list[0]=GMColumn(notr("No"),HEADER_TRACK,GMStreamTrackItem::ascendingTrack,GMStreamTrackItem::descendingTrack,60,true,true,0);
+  list[0]=GMColumn(notr("No."),HEADER_TRACK,GMStreamTrackItem::ascendingTrack,GMStreamTrackItem::descendingTrack,60,true,true,0);
   list[1]=GMColumn(notr("Station"),HEADER_TITLE,GMStreamTrackItem::ascendingTitle,GMStreamTrackItem::descendingTitle,200,true,true,1);
   list[2]=GMColumn(notr("Bit Rate"),HEADER_BITRATE,GMStreamTrackItem::ascendingTime,GMStreamTrackItem::descendingTime,80,true,true,2);
   list[3]=GMColumn(notr("Genre"),HEADER_TAG,GMStreamTrackItem::ascendingTrack,GMStreamTrackItem::descendingTrack,150,true,true,3);


### PR DESCRIPTION
"No" without the dot naturally translates as "Nein". As abbreviation for "Number", it translates to "Nr.". I've thus added the dot to the locations where "No" is used as the number sign.

I understand that British English does not use the dot. Using "No" without the dot requires context to disambiguate from other uses of "No". The GMTranslator does not provide the context functionality from gettext, so adding the dot character seems like the easier fix here. If it's not acceptable, I can try and use the context functionality.