### PR TITLE
set cmake_min version upper to prepare cmake-4 that requires >=3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-# Using cmake 3.2
-cmake_minimum_required(VERSION 3.3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(gogglesmm_dist)
 

--- a/cfox/CMakeLists.txt
+++ b/cfox/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.1)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
 

--- a/gap/CMakeLists.txt
+++ b/gap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 # set(CMAKE_VERBOSE_MAKEFILE TRUE)
 

--- a/gap/lib/alac/CMakeLists.txt
+++ b/gap/lib/alac/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 include(TestBigEndian)
 include(CheckIncludeFiles)

--- a/gap/lib/md5/CMakeLists.txt
+++ b/gap/lib/md5/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 include(TestBigEndian)
 include(CheckIncludeFiles)

--- a/gap/test/CMakeLists.txt
+++ b/gap/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(gap_tests)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 include(TestBigEndian)
 include(CheckIncludeFiles)


### PR DESCRIPTION
Set all with 3.5 could be sufficient but <3.10 will be removed then too. Here, 3.10 does not seem to conflict with any cmake_policy and is compatible with ubuntu 18.04 and debian 10.