### PR TITLE
import: switch from FXDirBox to FXPathBox for fox-1.7.87

### DIFF
--- a/src/GMImportDialog.cpp
+++ b/src/GMImportDialog.cpp
@@ -19,6 +19,9 @@
 #include <tag.h>
 #include "gmdefs.h"
 #include <FXArray.h>
+#if FOXVERSION >= FXVERSION(1, 7, 87)
+#include <FXPathBox.h>
+#endif
 #include <fxkeys.h>
 #include "icons.h"
 #include "GMTrack.h"
@@ -227,10 +230,14 @@ GMFileSelector::GMFileSelector(FXComposite *p,FXObject* tgt,FXSelector sel,FXuin
   filebox->setFocus();
   GMScrollArea::replaceScrollbars(filebox);
   new FXLabel(navbuttons,tr("Directory:"),nullptr,LAYOUT_CENTER_Y);
+  #if FOXVERSION < FXVERSION(1, 7, 87)
   dirbox=new FXDirBox(navbuttons,this,ID_DIRTREE,DIRBOX_NO_OWN_ASSOC|FRAME_LINE|LAYOUT_FILL_X|LAYOUT_CENTER_Y,0,0,0,0,1,1,1,1);
   dirbox->setNumVisible(5);
   //dirbox->setAssociations(filebox->getAssociations(),false);    // Shared file associations
   GMTreeListBox::replace(dirbox);
+  #else
+  dirbox=new FXPathBox(navbuttons,this,ID_DIRTREE,DIRBOX_NO_OWN_ASSOC|FRAME_LINE|LAYOUT_FILL_X|LAYOUT_CENTER_Y,0,0,0,0,1,1,1,1);
+  #endif
 
 
   bookmarkmenu=new GMMenuPane(this,POPUP_SHRINKWRAP);

--- a/src/fxext.cpp
+++ b/src/fxext.cpp
@@ -1685,6 +1685,7 @@ void GMScrollArea::replaceScrollbars(FXScrollArea *fs) {
 
 
 
+#if FOXVERSION < FXVERSION(1, 7, 87)
 FXIMPLEMENT(GMTreeListBox,FXTreeListBox,nullptr,0)
 
 void GMTreeListBox::replace(FXTreeListBox *fs) {
@@ -1701,6 +1702,7 @@ void GMTreeListBox::replace(FXTreeListBox *fs) {
   s->button->setYOffset(0);
   s->button->setXOffset(1);
   }
+#endif
 
 
 

--- a/src/fxext.h
+++ b/src/fxext.h
@@ -111,6 +111,7 @@ public:
 
 
 
+#if FOXVERSION < FXVERSION(1, 7, 87)
 class GMTreeListBox : public FXTreeListBox {
   FXDECLARE(GMTreeListBox)
 protected:
@@ -121,6 +122,7 @@ private:
 public:
   static void replace(FXTreeListBox*);
   };
+#endif
 
 
 class GMTabBook : public FXTabBook {


### PR DESCRIPTION
FXDirBox is obsolete in fox-1.7.87, so replace it with FXPathBox.
GMTreeListBox is obsolete too and don't need to be replaced w/ modern fox