### PR TITLE
Update includes for ioctl and soundcard headers

### DIFF
--- a/gap/plugins/ap_oss_plugin.cpp
+++ b/gap/plugins/ap_oss_plugin.cpp
@@ -23,10 +23,10 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <ioctl.h>
+#include <sys/ioctl.h>
 #include <unistd.h>
 
-#include <soundcard.h>
+#include <sys/soundcard.h>
 
 #include "ap_oss_defs.h"
 


### PR DESCRIPTION
This PR addresses build failures on GNU/Hurd:

1. **`fox/lib/FXReadWriteLock.cpp`**: Guard `PTHREAD_RWLOCK_PREFER_WRITER_NP` with `#ifdef` as this non-portable GNU extension is not available on Hurd.

As this is in a submodule I post the modification I made here (I also reported it to the fox-toolkit-project:
https://github.com/gogglesguy/fox/blob/0254309def05def353d6565b0f735b1963431fe8/lib/FXReadWriteLock.cpp#L75

`--- gogglesmm-1.3.1.orig/fox/lib/FXReadWriteLock.cpp
+++ gogglesmm-1.3.1/fox/lib/FXReadWriteLock.cpp
@@ -72,7 +72,9 @@ FXReadWriteLock::FXReadWriteLock(){
   FXSTATIC_ASSERT(sizeof(data)>=sizeof(pthread_rwlock_t));
   pthread_rwlockattr_t rwlockatt;
   pthread_rwlockattr_init(&rwlockatt);
+#ifdef PTHREAD_RWLOCK_PREFER_WRITER_NP

pthread_rwlockattr_setkind_np(&rwlockatt,PTHREAD_RWLOCK_PREFER_WRITER_NP);

+#endif
   pthread_rwlock_init((pthread_rwlock_t*)data,&rwlockatt);
   pthread_rwlockattr_destroy(&rwlockatt);
 #else
`

2. **`gap/plugins/ap_oss_plugin.cpp`**: 
   - Use `<sys/ioctl.h>` instead of `<ioctl.h>`.
   - Use `<sys/soundcard.h>` instead of `<soundcard.h>` for OSS declarations.

These changes allow `gogglesmm` to build cleanly on GNU/Hurd architectures while retaining full compatibility with Linux.